### PR TITLE
properly handle long(er) emails/passwords

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,7 @@ VERSION
 
 AUTHOR
 	Richard Crowley <richard@opendns.com>
+	Brian Hartvigsen <brian.hartvigsen@opendns.com>
 
 LICENSE
 	This work is licensed under a Creative Commons

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ INSTALLATION
 	PATH, as well.
 
 DEPENDENCIES
-	/bin/sh
+	BASH <http://www.gnu.org/software/bash/>
 	cURL <http://curl.haxx.se/>
 
 VERSION

--- a/fetchstats
+++ b/fetchstats
@@ -6,7 +6,6 @@
 #
 
 URL="https://opendns.com/dashboard"
-HEADING="Rank,Domain,Total,Blacklisted,Blocked by Category,Blocked by an Adult Category,Blocked as Phishing,Blocked as Malware,Resolved by SmartCache"
 
 usage() {
 	echo "Usage: $0 <username> <network_id> <YYYY-MM-DD> [<YYYY-MM-DD>]" >&2
@@ -61,15 +60,19 @@ curl --silent --insecure \
 	> /dev/null
 
 # Fetch pages of Top Domains
-echo "$HEADING"
 GO="yes"
 PAGE=1
 while [ "yes" = "$GO" ] ; do
 	CSV=$(curl --silent --insecure \
 		--cookie "$COOKIEJAR" \
-		"$URL/stats/$NETWORK_ID/topdomains/$DATE/page$PAGE.csv" \
-		| grep -v "$HEADING"
+		"$URL/stats/$NETWORK_ID/topdomains/$DATE/page$PAGE.csv"
 	)
+	if [ "$PAGE" == "1" ]; then
+		HEADING=`echo "$CSV" | head -n 1 -`
+	else
+		CSV=`echo "$CSV" | grep -v "$HEADING"`
+	fi
+
 	if [ -z "$CSV" ] ; then GO="no"
 	else echo "$CSV" ; fi
 	PAGE=$(($PAGE + 1))

--- a/fetchstats
+++ b/fetchstats
@@ -23,7 +23,7 @@ date_check() {
 	esac
 }
 
-USERNAME="$1"
+USERNAME=$(echo -n $1 |  od -t x1 -A n | tr " " %)
 if [ -z "$USERNAME" ] ; then usage ; fi
 NETWORK_ID="$2"
 if [ -z "$NETWORK_ID" ] ; then usage ; fi
@@ -40,7 +40,7 @@ stty -echo
 read PASSWORD
 stty echo
 echo "" >&2
-
+PASSWORD=$(echo -n "$PASSWORD" |  od -t x1 -A n | tr " " %)
 COOKIEJAR=$(mktemp /tmp/opendns-fetchstats-XXXXXX)
 
 # Get the signin page's form token

--- a/fetchstats
+++ b/fetchstats
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # OpenDNS Stats Fetcher
@@ -56,12 +56,16 @@ FORMTOKEN=`curl --silent --insecure \
 `
 
 # Sign into OpenDNS
-curl --silent --insecure \
+SIGNIN=`curl --silent --insecure \
 	--cookie "$COOKIEJAR" \
 	--cookie-jar "$COOKIEJAR" \
 	--data "formtoken=$FORMTOKEN&username=$USERNAME&password=$PASSWORD&sign_in_submit=foo" \
-	"$URL/signin" \
-	> /dev/null
+	"$URL/signin"`
+
+if [ "$SIGNIN" != "" ]; then
+	echo "Login failed.  Check username and password." >&2
+	exit 2
+fi
 
 # Fetch pages of Top Domains
 GO="yes"
@@ -72,6 +76,10 @@ while [ "yes" == "$GO" ] ; do
 		"$URL/stats/$NETWORK_ID/topdomains/$DATE/page$PAGE.csv" \
 	`
 	if [ "$PAGE" == "1" ]; then
+		if [ "$CSV" == "" ]; then
+			echo "You can not access $NETWORK_ID" >&2
+			exit 2
+		fi
 		HEADING=`echo "$CSV" | head -n 1`
 	else
 		CSV=`echo "$CSV" | grep -v "$HEADING"`

--- a/fetchstats
+++ b/fetchstats
@@ -2,6 +2,7 @@
 
 #
 # OpenDNS Stats Fetcher
+# Brian Hartvigsen <brian.hartvigsen@opendns.com>
 # Richard Crowley <richard@opendns.com>
 #
 
@@ -23,7 +24,7 @@ date_check() {
 	esac
 }
 
-USERNAME=$(echo -n $1 |  od -t x1 -A n | tr " " %)
+USERNAME=$1
 if [ -z "$USERNAME" ] ; then usage ; fi
 NETWORK_ID="$2"
 if [ -z "$NETWORK_ID" ] ; then usage ; fi
@@ -40,16 +41,19 @@ stty -echo
 read PASSWORD
 stty echo
 echo "" >&2
-PASSWORD=$(echo -n "$PASSWORD" |  od -t x1 -A n | tr " " %)
-COOKIEJAR=$(mktemp /tmp/opendns-fetchstats-XXXXXX)
+
+PASSWORD=`echo -n "$PASSWORD" | od -A n -t x1 | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
+USERNAME=`echo -n "$USERNAME" | od -A n -t x1 | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
+
+COOKIEJAR=`mktemp /tmp/opendns-fetchstats-XXXXXX`
 
 # Get the signin page's form token
-FORMTOKEN=$(curl --silent --insecure \
+FORMTOKEN=`curl --silent --insecure \
 	--cookie-jar "$COOKIEJAR" \
 	"$URL/signin" \
 	| grep formtoken \
 	| sed 's/^.*name="formtoken" value="\([0-9a-f]*\)".*$/\1/' \
-)
+`
 
 # Sign into OpenDNS
 curl --silent --insecure \
@@ -62,13 +66,13 @@ curl --silent --insecure \
 # Fetch pages of Top Domains
 GO="yes"
 PAGE=1
-while [ "yes" = "$GO" ] ; do
-	CSV=$(curl --silent --insecure \
+while [ "yes" == "$GO" ] ; do
+	CSV=`curl --silent --insecure \
 		--cookie "$COOKIEJAR" \
-		"$URL/stats/$NETWORK_ID/topdomains/$DATE/page$PAGE.csv"
-	)
+		"$URL/stats/$NETWORK_ID/topdomains/$DATE/page$PAGE.csv" \
+	`
 	if [ "$PAGE" == "1" ]; then
-		HEADING=`echo "$CSV" | head -n 1 -`
+		HEADING=`echo "$CSV" | head -n 1`
 	else
 		CSV=`echo "$CSV" | grep -v "$HEADING"`
 	fi
@@ -79,3 +83,4 @@ while [ "yes" = "$GO" ] ; do
 done
 
 rm -f "$COOKIEJAR"
+

--- a/fetchstats
+++ b/fetchstats
@@ -6,7 +6,7 @@
 #
 
 URL="https://opendns.com/dashboard"
-HEADING="Rank,Domain,Total,Blacklisted,Blocked by Category,Blocked as Phishing,Blocked as Malware"
+HEADING="Rank,Domain,Total,Blacklisted,Blocked by Category,Blocked by an Adult Category,Blocked as Phishing,Blocked as Malware,Resolved by SmartCache"
 
 usage() {
 	echo "Usage: $0 <username> <network_id> <YYYY-MM-DD> [<YYYY-MM-DD>]" >&2

--- a/fetchstats
+++ b/fetchstats
@@ -42,8 +42,8 @@ read PASSWORD
 stty echo
 echo "" >&2
 
-PASSWORD=`echo -n "$PASSWORD" | od -A n -t x1 | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
-USERNAME=`echo -n "$USERNAME" | od -A n -t x1 | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
+PASSWORD=`echo -n "$PASSWORD" | od -A n -t x1 | tr -d '\n' | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
+USERNAME=`echo -n "$USERNAME" | od -A n -t x1 | tr -d '\n' | sed 's/ *$//;s/[ ]\{1,\}/%/g'`
 
 COOKIEJAR=`mktemp /tmp/opendns-fetchstats-XXXXXX`
 


### PR DESCRIPTION
Some more changes for opendns-fetchstats.  Apparently people have email addresses (or passwords) longer than 16 characters, who'd-a-thunk-it :-P
